### PR TITLE
Adding ComputerVision "RecognizeText" operation

### DIFF
--- a/src/Orneholm.CognitiveWorkbench.Web/Controllers/VisionController.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Controllers/VisionController.cs
@@ -50,7 +50,7 @@ namespace Orneholm.CognitiveWorkbench.Web.Controllers
             Track("Vision_ComputerVision");
 
             var imageAnalyzer = new ImageComputerVisionAnalyzer(request.ComputerVisionSubscriptionKey, request.ComputerVisionEndpoint);
-            var analyzeResult = await imageAnalyzer.Analyze(request.ImageUrl, request.ImageAnalysisLanguage, request.ImageOcrLanguage);
+            var analyzeResult = await imageAnalyzer.Analyze(request.ImageUrl, request.ImageAnalysisLanguage, request.ImageOcrLanguage, request.ImageRecognizeTextMode);
 
             return View(ComputerVisionViewModel.Analyzed(request, analyzeResult));
         }

--- a/src/Orneholm.CognitiveWorkbench.Web/Extensions/ImageAnalysisExtensions.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Extensions/ImageAnalysisExtensions.cs
@@ -156,6 +156,17 @@ namespace Orneholm.CognitiveWorkbench.Web.Extensions
             return $"X: {box[0]}; Y: {box[1]}; W: {box[2]}; H: {box[3]}";
         }
 
+        public static string ToDescription(this IList<double> boundingBox)
+        {
+            // BoundingBox: Bounding box of a recognized region, line, or word, depending on the parent object.
+            // The eight integers represent the four points (x-coordinate, y-coordinate) of the detected rectangle
+            // from the left-top corner and clockwise.
+            var maxWidth = Math.Max(boundingBox[2] - boundingBox[0], boundingBox[6] - boundingBox[4]);
+            var maxHeight = Math.Max(boundingBox[7] - boundingBox[1], boundingBox[5] - boundingBox[3]);
+
+            return $"X: {boundingBox[0]}, Y: {boundingBox[1]}, MaxW: {maxWidth}, MaxH: {maxHeight}";
+        }
+
         public static string ToDescription(this FaceRectangle faceRectangle)
         {
             return $"X: {faceRectangle.Left}; Y: {faceRectangle.Top}; W: {faceRectangle.Width}; H: {faceRectangle.Height}";
@@ -183,6 +194,20 @@ namespace Orneholm.CognitiveWorkbench.Web.Extensions
                    $"top: {box[1].ToCssPercentageString(imageHeight)}; " +
                    $"width: {box[2].ToCssPercentageString(imageWidth)}; " +
                    $"height: {box[3].ToCssPercentageString(imageHeight)};";
+        }
+
+        public static string ToCss(this IList<double> boundingBox, int imageWidth, int imageHeight)
+        {
+            // BoundingBox: Bounding box of a recognized region, line, or word, depending on the parent object.
+            // The eight integers represent the four points (x-coordinate, y-coordinate) of the detected rectangle
+            // from the left-top corner and clockwise.
+            var maxWidth = Math.Max(boundingBox[2] - boundingBox[0], boundingBox[6] - boundingBox[4]);
+            var maxHeight = Math.Max(boundingBox[7] - boundingBox[1], boundingBox[5] - boundingBox[3]);
+
+            return $"left: {boundingBox[0].ToCssPercentageString(imageWidth)}; " +
+                   $"top: {boundingBox[1].ToCssPercentageString(imageHeight)}; " +
+                   $"width: {maxWidth.ToCssPercentageString(imageWidth)}; " +
+                   $"height: {maxHeight.ToCssPercentageString(imageHeight)};";
         }
 
         public static string ToCss(this FaceRectangle boundingRect, int imageWidth, int imageHeight)

--- a/src/Orneholm.CognitiveWorkbench.Web/Extensions/ImageAnalysisExtensions.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Extensions/ImageAnalysisExtensions.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.Azure.CognitiveServices.Vision.ComputerVision.Models;
 using Microsoft.Azure.CognitiveServices.Vision.Face.Models;
+using Orneholm.CognitiveWorkbench.Web.Models;
 using FaceRectangle = Microsoft.Azure.CognitiveServices.Vision.ComputerVision.Models.FaceRectangle;
 
 namespace Orneholm.CognitiveWorkbench.Web.Extensions
@@ -161,10 +162,8 @@ namespace Orneholm.CognitiveWorkbench.Web.Extensions
             // BoundingBox: Bounding box of a recognized region, line, or word, depending on the parent object.
             // The eight integers represent the four points (x-coordinate, y-coordinate) of the detected rectangle
             // from the left-top corner and clockwise.
-            var maxWidth = Math.Max(boundingBox[2] - boundingBox[0], boundingBox[6] - boundingBox[4]);
-            var maxHeight = Math.Max(boundingBox[7] - boundingBox[1], boundingBox[5] - boundingBox[3]);
-
-            return $"X: {boundingBox[0]}, Y: {boundingBox[1]}, MaxW: {maxWidth}, MaxH: {maxHeight}";
+            var bb = new RecognizeTextRotatedBoundingBox(boundingBox);
+            return $"MinX: {bb.MinLeft()}, MinY: {bb.MinTop()}, MaxW: {bb.MaxWidth()}, MaxH: {bb.MaxHeight()}";
         }
 
         public static string ToDescription(this FaceRectangle faceRectangle)
@@ -201,13 +200,11 @@ namespace Orneholm.CognitiveWorkbench.Web.Extensions
             // BoundingBox: Bounding box of a recognized region, line, or word, depending on the parent object.
             // The eight integers represent the four points (x-coordinate, y-coordinate) of the detected rectangle
             // from the left-top corner and clockwise.
-            var maxWidth = Math.Max(boundingBox[2] - boundingBox[0], boundingBox[6] - boundingBox[4]);
-            var maxHeight = Math.Max(boundingBox[7] - boundingBox[1], boundingBox[5] - boundingBox[3]);
-
-            return $"left: {boundingBox[0].ToCssPercentageString(imageWidth)}; " +
-                   $"top: {boundingBox[1].ToCssPercentageString(imageHeight)}; " +
-                   $"width: {maxWidth.ToCssPercentageString(imageWidth)}; " +
-                   $"height: {maxHeight.ToCssPercentageString(imageHeight)};";
+            var bb = new RecognizeTextRotatedBoundingBox(boundingBox);
+            return $"left: {bb.MinLeft().ToCssPercentageString(imageWidth)}; " +
+                   $"top: {bb.MinTop().ToCssPercentageString(imageHeight)}; " +
+                   $"width: {bb.MaxWidth().ToCssPercentageString(imageWidth)}; " +
+                   $"height: {bb.MaxHeight().ToCssPercentageString(imageHeight)};";
         }
 
         public static string ToCss(this FaceRectangle boundingRect, int imageWidth, int imageHeight)

--- a/src/Orneholm.CognitiveWorkbench.Web/Models/ComputerVisionAnalyzeRequest.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Models/ComputerVisionAnalyzeRequest.cs
@@ -8,5 +8,6 @@ namespace Orneholm.CognitiveWorkbench.Web.Models
         public string ImageUrl { get; set; } = string.Empty;
         public string ImageAnalysisLanguage { get; set; } = string.Empty;
         public string ImageOcrLanguage { get; set; } = string.Empty;
+        public string ImageRecognizeTextMode { get; set; } = string.Empty;
     }
 }

--- a/src/Orneholm.CognitiveWorkbench.Web/Models/ComputerVisionAnalyzeResponse.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Models/ComputerVisionAnalyzeResponse.cs
@@ -13,6 +13,7 @@ namespace Orneholm.CognitiveWorkbench.Web.Models
 
         public ImageAnalysis AnalysisResult { get; set; } = new ImageAnalysis();
         public OcrResult OcrResult { get; set; } = new OcrResult();
+        public TextOperationResult RecognizeTextOperationResult { get; set; } = new TextOperationResult();
         public AreaOfInterestResult AreaOfInterestResult { get; set; } = new AreaOfInterestResult();
 
         public List<DetectedFace> FaceResult { get; set; } = new List<DetectedFace>();

--- a/src/Orneholm.CognitiveWorkbench.Web/Models/RecognizeTextRotatedBoundingBox.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Models/RecognizeTextRotatedBoundingBox.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Orneholm.CognitiveWorkbench.Web.Models
+{
+    public class RecognizeTextRotatedBoundingBox
+    {
+        public RecognizeTextRotatedBoundingBox(IList<double> boundingBoxCoords)
+        {
+            var boundingBoxPoints = new List<RecognizeTextRotatedBoundingBoxPoint>
+            {
+                new RecognizeTextRotatedBoundingBoxPoint
+                {
+                    X = boundingBoxCoords[0],
+                    Y = boundingBoxCoords[1]
+                },
+                new RecognizeTextRotatedBoundingBoxPoint
+                {
+                    X = boundingBoxCoords[2],
+                    Y = boundingBoxCoords[3]
+                },
+                new RecognizeTextRotatedBoundingBoxPoint
+                {
+                    X = boundingBoxCoords[4],
+                    Y = boundingBoxCoords[5]
+                },
+                new RecognizeTextRotatedBoundingBoxPoint
+                {
+                    X = boundingBoxCoords[6],
+                    Y = boundingBoxCoords[7]
+                }
+            };
+
+            // Points may not be ordered correctly 
+            TopLeft = boundingBoxPoints
+                .OrderBy(p => p.X).Take(2)
+                .OrderBy(p => p.Y).First();
+            TopRight = boundingBoxPoints
+                .OrderByDescending(p => p.X).Take(2)
+                .OrderBy(p => p.Y).First();
+            BottomRight = boundingBoxPoints
+                .OrderByDescending(p => p.X).Take(2)
+                .OrderByDescending(p => p.Y).First();
+            BottomLeft = boundingBoxPoints
+                .OrderBy(p => p.X).Take(2)
+                .OrderByDescending(p => p.Y).First();
+        }
+
+        public RecognizeTextRotatedBoundingBoxPoint TopLeft { get; set; }
+
+        public RecognizeTextRotatedBoundingBoxPoint TopRight { get; set; }
+
+        public RecognizeTextRotatedBoundingBoxPoint BottomLeft { get; set; }
+
+        public RecognizeTextRotatedBoundingBoxPoint BottomRight { get; set; }
+
+        public double MinLeft()
+        {
+            return Math.Min(TopLeft.X, BottomLeft.X);
+        }
+
+        public double MinTop()
+        {
+            return Math.Min(TopLeft.Y, TopRight.Y);
+        }
+
+        public double MaxWidth()
+        {
+            return Math.Max(TopRight.X, BottomRight.X) - Math.Min(TopLeft.X, BottomLeft.X);
+        }
+
+        public double MaxHeight()
+        {
+            return Math.Max(BottomLeft.Y, BottomRight.Y) - Math.Min(TopLeft.Y, TopRight.Y);
+        }
+    }
+}

--- a/src/Orneholm.CognitiveWorkbench.Web/Models/RecognizeTextRotatedBoundingBoxPoint.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Models/RecognizeTextRotatedBoundingBoxPoint.cs
@@ -1,0 +1,9 @@
+namespace Orneholm.CognitiveWorkbench.Web.Models
+{
+    public class RecognizeTextRotatedBoundingBoxPoint
+    {
+        public double X { get; set; }
+
+        public double Y { get; set; }
+    }
+}

--- a/src/Orneholm.CognitiveWorkbench.Web/Services/ImageComputerVisionAnalyzer.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Services/ImageComputerVisionAnalyzer.cs
@@ -70,7 +70,7 @@ namespace Orneholm.CognitiveWorkbench.Web.Services
 
                 AnalysisResult = imageAnalysis.Result,
                 OcrResult = recognizedPrintedText.Result,
-                RecognizeTextOperationResult = recognizedText?.Result,
+                RecognizeTextOperationResult = recognizedText.Result,
                 AreaOfInterestResult = areaOfInterest.Result
             };
         }
@@ -102,18 +102,18 @@ namespace Orneholm.CognitiveWorkbench.Web.Services
             var result = await _computerVisionClient.GetTextOperationResultAsync(operationId);
 
             // Wait for the operation to complete
-            var i = 1;
+            var iteration = 1;
             var waitDurationInMs = 500;
             var maxWaitTimeInMs = 30000;
             var maxTries = maxWaitTimeInMs / waitDurationInMs;
 
             while ((result.Status == TextOperationStatusCodes.Running || result.Status == TextOperationStatusCodes.NotStarted)
-                && i <= maxTries)
+                && iteration <= maxTries)
             {
                 await Task.Delay(waitDurationInMs);
 
                 result = await _computerVisionClient.GetTextOperationResultAsync(operationId);
-                i++;
+                iteration++;
             }
 
             return result;

--- a/src/Orneholm.CognitiveWorkbench.Web/Services/ImageComputerVisionAnalyzer.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Services/ImageComputerVisionAnalyzer.cs
@@ -70,7 +70,7 @@ namespace Orneholm.CognitiveWorkbench.Web.Services
 
                 AnalysisResult = imageAnalysis.Result,
                 OcrResult = recognizedPrintedText.Result,
-                RecognizeTextOperationResult = recognizedText.Result,
+                RecognizeTextOperationResult = recognizedText?.Result,
                 AreaOfInterestResult = areaOfInterest.Result
             };
         }
@@ -116,15 +116,7 @@ namespace Orneholm.CognitiveWorkbench.Web.Services
                 i++;
             }
 
-            // Process result
-            if (result.Status == TextOperationStatusCodes.Succeeded)
-            {
-                return result;
-            }
-            else
-            {
-                return null;
-            }
+            return result;
         }
 
         private static TextRecognitionMode GetTextRecognitionMode(string recognizeTextMode, TextRecognitionMode defaultMode)

--- a/src/Orneholm.CognitiveWorkbench.Web/Views/Shared/_RecognizeTextOperationResult.cshtml
+++ b/src/Orneholm.CognitiveWorkbench.Web/Views/Shared/_RecognizeTextOperationResult.cshtml
@@ -1,0 +1,84 @@
+@using Orneholm.CognitiveWorkbench.Web.Extensions
+@model Microsoft.Azure.CognitiveServices.Vision.ComputerVision.Models.TextOperationResult
+
+<div class="mb-5">
+    <h4>Metadata</h4>
+
+    <table class="table table-striped table-hover">
+        <thead class="thead-dark">
+            <tr>
+                <th>Key</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th>Status</th>
+                <td>@Model.Status</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+
+<div class="my-5">
+    <h4>Lines</h4>
+
+    <table class="table table-striped table-hover">
+        <thead class="thead-dark">
+            <tr>
+                <th>Rectangle</th>
+                <th>Words</th>
+            </tr>
+        </thead>
+        <tbody class="cwb-image-boxes-table" data-cwb-for=".cwb-image-boxes-ocr-lines">
+            @foreach (var line in Model.RecognitionResult?.Lines)
+            {
+                <tr>
+                    <th>@line.BoundingBox.ToDescription()</th>
+                    <td>@string.Join(" ", line.Words.Select(x => x.Text))</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+
+    @if (Model.RecognitionResult?.Lines == null || !Model.RecognitionResult.Lines.Any())
+    {
+        <p class="p-2">
+            No lines available.
+        </p>
+    }
+</div>
+
+
+<div class="mt-5">
+    <h4>Words</h4>
+
+    <table class="table table-striped table-hover">
+        <thead class="thead-dark">
+            <tr>
+                <th>Rectangle</th>
+                <th>Text</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var line in Model.RecognitionResult?.Lines)
+            {
+                foreach (var word in line.Words)
+                {
+                    <tr>
+                        <th>@word.BoundingBox.ToDescription()</th>
+                        <td>@word.Text</td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+
+    @if (Model.RecognitionResult?.Lines == null || !Model.RecognitionResult.Lines.Any())
+    {
+        <p class="p-2">
+            No words available.
+        </p>
+    }
+</div>

--- a/src/Orneholm.CognitiveWorkbench.Web/Views/Shared/_RecognizeTextOperationResult.cshtml
+++ b/src/Orneholm.CognitiveWorkbench.Web/Views/Shared/_RecognizeTextOperationResult.cshtml
@@ -31,7 +31,7 @@
                 <th>Words</th>
             </tr>
         </thead>
-        <tbody class="cwb-image-boxes-table" data-cwb-for=".cwb-image-boxes-ocr-lines">
+        <tbody class="cwb-image-boxes-table" data-cwb-for=".cwb-image-boxes-recognizetext-lines">
             @foreach (var line in Model.RecognitionResult?.Lines)
             {
                 <tr>

--- a/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/ComputerVision.cshtml
+++ b/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/ComputerVision.cshtml
@@ -297,7 +297,7 @@
                         <div class="card mb-3 cwb-result-image">
                             <img src="@Model.ComputerVisionAnalyzeResponse.ImageInfo.Url" class="card-img-top" alt="@Model.ComputerVisionAnalyzeResponse.ImageInfo.Description" />
                             <div class="cwb-image-boxes">
-                                <div class="cwb-image-boxes-ocr-lines">
+                                <div class="cwb-image-boxes-recognizetext-lines">
                                     @foreach (var line in Model.ComputerVisionAnalyzeResponse.RecognizeTextOperationResult.RecognitionResult.Lines)
                                     {
                                         <div class="cwb-image-box"

--- a/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/ComputerVision.cshtml
+++ b/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/ComputerVision.cshtml
@@ -54,6 +54,12 @@
                                         <input type="text" required class="cwb-input-remember form-control" placeholder="en" asp-for="ComputerVisionAnalyzeRequest.ImageOcrLanguage" name="ImageOcrLanguage" />
                                     </div>
                                 </div>
+                                <div class="col">
+                                    <div class="form-group">
+                                        <label asp-for="ComputerVisionAnalyzeRequest.ImageRecognizeTextMode">Image Recognize Text Mode</label>
+                                        <input type="text" required class="cwb-input-remember form-control" placeholder="Printed" asp-for="ComputerVisionAnalyzeRequest.ImageRecognizeTextMode" name="ImageRecognizeTextMode" />
+                                    </div>
+                                </div>
                             </div>
 
                             <div class="form-group">
@@ -281,8 +287,60 @@
             </section>
         }
 
+        @if (Model.IsAnalyzed && Model.ComputerVisionAnalyzeResponse?.RecognizeTextOperationResult != null)
+        {
+            <section class="cwb-result-computervision-analyze">
+                <h2 class="mt-5">Computer Vision - Recognize Text</h2>
+
+                <div class="row">
+                    <div class="col-md-7">
+                        <div class="card mb-3 cwb-result-image">
+                            <img src="@Model.ComputerVisionAnalyzeResponse.ImageInfo.Url" class="card-img-top" alt="@Model.ComputerVisionAnalyzeResponse.ImageInfo.Description" />
+                            <div class="cwb-image-boxes">
+                                <div class="cwb-image-boxes-ocr-lines">
+                                    @foreach (var line in Model.ComputerVisionAnalyzeResponse.RecognizeTextOperationResult.RecognitionResult.Lines)
+                                    {
+                                        <div class="cwb-image-box"
+                                                style="@line.BoundingBox.ToCss(Model.ComputerVisionAnalyzeResponse.ImageInfo.Width, Model.ComputerVisionAnalyzeResponse.ImageInfo.Height)">
+                                            <div class="cwb-image-box-info" title="@string.Join(" ", line.Words.Select(x => x.Text))">
+                                                <span class="cwb-image-box-type">Line</span>
+                                            </div>
+                                        </div>
+                                    }
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-5">
+                        <div class="card mb-3 cwb-result-content">
+                            <div class="card-header">
+                                <ul class="nav nav-tabs card-header-tabs">
+                                    <li class="nav-item">
+                                        <a class="nav-link active" data-toggle="list" href="#cwb-result-computervision-recognizetext-info">Info (Parsed)</a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link" data-toggle="list" href="#cwb-result-computervision-recognizetext-json">JSON (Raw)</a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="card-body">
+                                <div class="tab-content">
+                                    <div class="tab-pane fade show active" id="cwb-result-computervision-recognizetext-info">
+                                        <partial name="_RecognizeTextOperationResult" model="@Model.ComputerVisionAnalyzeResponse.RecognizeTextOperationResult" />
+                                    </div>
+                                    <div class="tab-pane fade" id="cwb-result-computervision-recognizetext-json">
+                                        <partial name="_Json" model="@Model.ComputerVisionAnalyzeResponse.RecognizeTextOperationResult" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        }
+
         @section Scripts
-{
+        {
             <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
             <script>
                 (function () {


### PR DESCRIPTION
Adding "RecognizeText" operation from Computer Vision API (see doc https://westeurope.dev.cognitive.microsoft.com/docs/services/5cd27ec07268f6c679a3e641/operations/587f2c6a1540550560080311)

Small hack in results display: I reused the css style for other kind of results, so I am converting the polygon bounding to a rectangle one. And I had to order the points as the result is sent given the text orientation (from top left corner of the text, clockwise)
A good (future) thing would be to change that to real polygons.

Sample:
![image](https://user-images.githubusercontent.com/6305666/76146409-cc760600-6092-11ea-92bd-ed32646ac8ec.png)
