### PR TITLE
Face - Add DetectionModels parameter

### DIFF
--- a/src/Orneholm.CognitiveWorkbench.Web/Controllers/VisionController.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Controllers/VisionController.cs
@@ -83,7 +83,7 @@ namespace Orneholm.CognitiveWorkbench.Web.Controllers
             Track("Vision_Face");
 
             var imageAnalyzer = new ImageFaceAnalyzer(request.FaceSubscriptionKey, request.FaceEndpoint, _httpClientFactory);
-            var analyzeResult = await imageAnalyzer.Analyze(request.ImageUrl);
+            var analyzeResult = await imageAnalyzer.Analyze(request.ImageUrl, request.DetectionModel);
 
             return View(FaceViewModel.Analyzed(request, analyzeResult));
         }

--- a/src/Orneholm.CognitiveWorkbench.Web/Models/FaceAnalyzeRequest.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Models/FaceAnalyzeRequest.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Orneholm.CognitiveWorkbench.Web.Models
 {
     public class FaceAnalyzeRequest
@@ -6,5 +8,14 @@ namespace Orneholm.CognitiveWorkbench.Web.Models
         public string FaceEndpoint { get; set; } = string.Empty;
 
         public string ImageUrl { get; set; } = string.Empty;
+        public FaceDetectionModel DetectionModel { get; set; } = FaceDetectionModel.detection_01;
+    }
+
+    public enum FaceDetectionModel
+    {
+        [Display(Name = "Detection 01 - Default")]
+        detection_01,
+        [Display(Name = "Detection 02 - Improved accuracy especially on small, side and blurry faces but no face attributes and landmarks")]
+        detection_02
     }
 }

--- a/src/Orneholm.CognitiveWorkbench.Web/Views/Shared/_DetectResult.cshtml
+++ b/src/Orneholm.CognitiveWorkbench.Web/Views/Shared/_DetectResult.cshtml
@@ -16,8 +16,8 @@
             @foreach (var face in Model.FaceResult)
             {
                 <tr>
-                    <th>@face.FaceAttributes.Age</th>
-                    <th>@face.FaceAttributes.Smile</th>
+                    <th>@face.FaceAttributes?.Age</th>
+                    <th>@face.FaceAttributes?.Smile</th>
                     <th>@face.FaceRectangle.ToDescription()</th>
                 </tr>
             }

--- a/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/Face.cshtml
+++ b/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/Face.cshtml
@@ -5,7 +5,7 @@
         <h2>Vision - Face</h2>
 
         <p>
-            Identify and analyze content within images. Objects, faces, landmarks, celebrities etc.
+            Detect faces within images. Face landmarks, emotion, etc.
         </p>
 
         <form method="post">
@@ -29,10 +29,14 @@
                                         The image must be presented in JPEG, PNG, GIF, or BMP
                                     </li>
                                     <li>
-                                        The file size of the image must be less than 4 megabytes (MB)
+                                        The allowed image file size is from 1 KB to 6 MB
                                     </li>
                                     <li>
-                                        The dimensions of the image must be greater than 50 x 50 pixels
+                                        The minimum detectable face size is 36x36 pixels in an image no larger than 1920x1080 pixels.<br />
+                                        Images with dimensions higher than 1920x1080 pixels will need a proportionally larger minimum face size.
+                                    </li>
+                                    <li>
+                                        Up to 100 faces can be returned for an image. Faces are ranked by face rectangle size from large to small.
                                     </li>
                                 </ul>
                             </p>
@@ -40,6 +44,16 @@
                             <p class="mb-3">
                                 <strong>Note:</strong> You need to provide your own keys for Azure Cognitive Services - Face under the tab <em>Settings</em>.
                             </p>
+
+                            <div class="form-row">
+                                <div class="col">
+                                    <div class="form-group">
+                                        <label asp-for="FaceAnalyzeRequest.DetectionModel">Detection model</label>
+                                        <select asp-for="FaceAnalyzeRequest.DetectionModel" asp-items="Html.GetEnumSelectList<FaceDetectionModel>()" required class="cwb-input-remember form-control" name="DetectionModel">
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
 
                             <div class="form-group">
                                 <label asp-for=FaceAnalyzeRequest.ImageUrl>Image URL</label>
@@ -84,9 +98,12 @@
                                 <div class="cwb-image-boxes-faces-full">
                                     @foreach (var face in Model.FaceAnalyzeResponse.FaceResult)
                                     {
-                                        <div class="cwb-image-box"
-                                             style="@face.FaceRectangle.ToCss(Model.FaceAnalyzeResponse.ImageInfo.Width, Model.FaceAnalyzeResponse.ImageInfo.Height)">
-                                            <div class="cwb-image-box-info" title="@face.FaceAttributes.Age years old">
+                                    <div class="cwb-image-box"
+                                         style="@face.FaceRectangle.ToCss(Model.FaceAnalyzeResponse.ImageInfo.Width, Model.FaceAnalyzeResponse.ImageInfo.Height)">
+
+                                        @if (face.FaceAttributes != null)
+                                        {
+                                            <div class="cwb-image-box-info" title="@face.FaceAttributes?.Age years old">
                                                 <span class="cwb-image-box-type">Face</span>
                                                 <span class="cwb-image-box-description">@face.FaceAttributes.Emotion.ToEmotion()</span>
                                             </div>
@@ -150,7 +167,16 @@
                                                     </tbody>
                                                 </table>
                                             </div>
+                                        }
+                                        else
+                                        {
+                                            <div class="cwb-image-box-info">
+                                                <span class="cwb-image-box-type">Face</span>
+                                            </div>
+                                        }
 
+                                        @if (face.FaceLandmarks != null)
+                                        {
                                             <div class="cwb-image-box-landmarks">
                                                 @foreach (var landmark in face.FaceLandmarks.ToFaceLandmarks())
                                                 {
@@ -159,7 +185,8 @@
                                                          style="@landmark.Value.ToRelativeCss(face.FaceRectangle, Model.FaceAnalyzeResponse.ImageInfo.Width, Model.FaceAnalyzeResponse.ImageInfo.Height)"></div>
                                                 }
                                             </div>
-                                        </div>
+                                        }
+                                    </div>
                                     }
                                 </div>
                             </div>


### PR DESCRIPTION
Adding the "detection model" choice in Face part.

Sample: https://i.ytimg.com/vi/18eakDpvCIY/maxresdefault.jpg
- Detection 01 result: only one face found
- Detection 02 result: 2 faces found

Note: Detection 02 model has better detections but does not provide face landmarks nor face attributes (see [doc](https://westeurope.dev.cognitive.microsoft.com/docs/services/563879b61984550e40cbbe8d/operations/563879b61984550f30395236)):

> Different 'detectionModel' values can be provided. To use and compare different detection models, please refer to How to specify a detection model
> - 'detection_01': The default detection model for Face - Detect. Recommend for near frontal face detection. For scenarios with exceptionally large angle (head-pose) faces, occluded faces or wrong image orientation, the faces in such cases may not be detected.
> - 'detection_02': Detection model released in 2019 May with improved accuracy especially on small, side and blurry faces. Face attributes and landmarks are disabled if you choose this detection model.