### PR TITLE
API Errors check and user feedback

### DIFF
--- a/src/Orneholm.CognitiveWorkbench.Web/Controllers/VisionController.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Controllers/VisionController.cs
@@ -37,17 +37,17 @@ namespace Orneholm.CognitiveWorkbench.Web.Controllers
             var errorContent = "";
             if (string.IsNullOrWhiteSpace(request.ComputerVisionSubscriptionKey))
             {
-                errorContent += $"Missing or invalid ComputerVisionSubscriptionKey{Environment.NewLine}";
+                errorContent += $"Missing or invalid Computer Vision Subscription Key (see 'Azure Settings' tab){Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.ComputerVisionEndpoint))
             {
-                errorContent += $"Missing or invalid ComputerVisionEndpoint{Environment.NewLine}";
+                errorContent += $"Missing or invalid Computer Vision Endpoint (see 'Azure Settings' tab){Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.ImageUrl))
             {
-                errorContent += $"Missing or invalid ImageUrl";
+                errorContent += $"Missing or invalid Image Url";
             }
 
             if (!string.IsNullOrWhiteSpace(errorContent))
@@ -80,27 +80,27 @@ namespace Orneholm.CognitiveWorkbench.Web.Controllers
             var errorContent = "";
             if (string.IsNullOrWhiteSpace(request.CustomVisionPredictionKey))
             {
-                errorContent += $"Missing or invalid CustomVisionPredictionKey{Environment.NewLine}";
+                errorContent += $"Missing or invalid Custom Vision Prediction Key (see 'Azure Settings' tab){Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.CustomVisionEndpoint))
             {
-                errorContent += $"Missing or invalid CustomVisionEndpoint{Environment.NewLine}";
+                errorContent += $"Missing or invalid Custom Vision Prediction Endpoint (see 'Azure Settings' tab){Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.ImageUrl))
             {
-                errorContent += $"Missing or invalid ImageUrl{Environment.NewLine}";
+                errorContent += $"Missing or invalid Image Url{Environment.NewLine}";
             }
 
             if (request.ProjectId == null || Guid.Empty.Equals(request.ProjectId))
             {
-                errorContent += $"Missing or invalid ProjectId{Environment.NewLine}";
+                errorContent += $"Missing or invalid Project Id{Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.IterationPublishedName))
             {
-                errorContent += $"Missing or invalid IterationPublishedName{Environment.NewLine}";
+                errorContent += $"Missing or invalid Iteration Published Name{Environment.NewLine}";
             }
 
             if (!string.IsNullOrWhiteSpace(errorContent))
@@ -133,22 +133,22 @@ namespace Orneholm.CognitiveWorkbench.Web.Controllers
             var errorContent = "";
             if (string.IsNullOrWhiteSpace(request.FaceSubscriptionKey))
             {
-                errorContent += $"Missing or invalid FaceSubscriptionKey{Environment.NewLine}";
+                errorContent += $"Missing or invalid Face Subscription Key (see 'Azure Settings' tab){Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.FaceEndpoint))
             {
-                errorContent += $"Missing or invalid FaceEndpoint{Environment.NewLine}";
+                errorContent += $"Missing or invalid Face Endpoint (see 'Azure Settings' tab){Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.ImageUrl))
             {
-                errorContent += $"Missing or invalid ImageUrl{Environment.NewLine}";
+                errorContent += $"Missing or invalid Image Url{Environment.NewLine}";
             }
 
             if (request.EnableIdentification && string.IsNullOrWhiteSpace(request.IdentificationGroupId))
             {
-                errorContent += $"Missing or invalid IdentificationGroupId{Environment.NewLine}";
+                errorContent += $"Missing or invalid Identification Group Id{Environment.NewLine}";
             }
 
             if (!string.IsNullOrWhiteSpace(errorContent))

--- a/src/Orneholm.CognitiveWorkbench.Web/Controllers/VisionController.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Controllers/VisionController.cs
@@ -34,19 +34,30 @@ namespace Orneholm.CognitiveWorkbench.Web.Controllers
         [HttpPost("/vision/computer-vision")]
         public async Task<ActionResult<ComputerVisionViewModel>> ComputerVision([FromForm]ComputerVisionAnalyzeRequest request)
         {
+            var errorContent = "";
             if (string.IsNullOrWhiteSpace(request.ComputerVisionSubscriptionKey))
             {
-                throw new ArgumentException("Missing or invalid ComputerVisionSubscriptionKey", nameof(request.ComputerVisionSubscriptionKey));
+                errorContent += $"Missing or invalid ComputerVisionSubscriptionKey{Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.ComputerVisionEndpoint))
             {
-                throw new ArgumentException("Missing or invalid ComputerVisionEndpoint", nameof(request.ComputerVisionEndpoint));
+                errorContent += $"Missing or invalid ComputerVisionEndpoint{Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.ImageUrl))
             {
-                throw new ArgumentException("Missing or invalid ImageUrl", nameof(request.ImageUrl));
+                errorContent += $"Missing or invalid ImageUrl";
+            }
+
+            if (!string.IsNullOrWhiteSpace(errorContent))
+            {
+                return View(ComputerVisionViewModel.Analyzed(request, 
+                    new ComputerVisionAnalyzeResponse
+                    {
+                        OtherErrorMessage = "Request not processed due to the following error(s):",
+                        OtherErrorContent = errorContent
+                    }));
             }
 
             Track("Vision_ComputerVision");
@@ -66,29 +77,40 @@ namespace Orneholm.CognitiveWorkbench.Web.Controllers
         [HttpPost("/vision/custom-vision")]
         public async Task<ActionResult<CustomVisionViewModel>> CustomVision([FromForm]CustomVisionRequest request)
         {
+            var errorContent = "";
             if (string.IsNullOrWhiteSpace(request.CustomVisionPredictionKey))
             {
-                throw new ArgumentException("Missing or invalid CustomVisionPredictionKey", nameof(request.CustomVisionPredictionKey));
+                errorContent += $"Missing or invalid CustomVisionPredictionKey{Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.CustomVisionEndpoint))
             {
-                throw new ArgumentException("Missing or invalid CustomVisionEndpoint", nameof(request.CustomVisionEndpoint));
+                errorContent += $"Missing or invalid CustomVisionEndpoint{Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.ImageUrl))
             {
-                throw new ArgumentException("Missing or invalid ImageUrl", nameof(request.ImageUrl));
+                errorContent += $"Missing or invalid ImageUrl{Environment.NewLine}";
             }
 
             if (request.ProjectId == null || Guid.Empty.Equals(request.ProjectId))
             {
-                throw new ArgumentException("Missing or invalid ProjectId", nameof(request.ProjectId));
+                errorContent += $"Missing or invalid ProjectId{Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.IterationPublishedName))
             {
-                throw new ArgumentException("Missing or invalid IterationPublishedName", nameof(request.IterationPublishedName));
+                errorContent += $"Missing or invalid IterationPublishedName{Environment.NewLine}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(errorContent))
+            {
+                return View(CustomVisionViewModel.Analyzed(request, 
+                    new CustomVisionResponse
+                    {
+                        OtherErrorMessage = "Request not processed due to the following error(s):",
+                        OtherErrorContent = errorContent
+                    }));
             }
 
             Track("Vision_CustomVision");
@@ -108,24 +130,35 @@ namespace Orneholm.CognitiveWorkbench.Web.Controllers
         [HttpPost("/vision/face")]
         public async Task<ActionResult<FaceViewModel>> Face([FromForm]FaceAnalyzeRequest request)
         {
+            var errorContent = "";
             if (string.IsNullOrWhiteSpace(request.FaceSubscriptionKey))
             {
-                throw new ArgumentException("Missing or invalid FaceSubscriptionKey", nameof(request.FaceSubscriptionKey));
+                errorContent += $"Missing or invalid FaceSubscriptionKey{Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.FaceEndpoint))
             {
-                throw new ArgumentException("Missing or invalid FaceEndpoint", nameof(request.FaceEndpoint));
+                errorContent += $"Missing or invalid FaceEndpoint{Environment.NewLine}";
             }
 
             if (string.IsNullOrWhiteSpace(request.ImageUrl))
             {
-                throw new ArgumentException("Missing or invalid ImageUrl", nameof(request.ImageUrl));
+                errorContent += $"Missing or invalid ImageUrl{Environment.NewLine}";
             }
 
             if (request.EnableIdentification && string.IsNullOrWhiteSpace(request.IdentificationGroupId))
             {
-                throw new ArgumentException("Missing or invalid IdentificationGroupId", nameof(request.IdentificationGroupId));
+                errorContent += $"Missing or invalid IdentificationGroupId{Environment.NewLine}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(errorContent))
+            {
+                return View(FaceViewModel.Analyzed(request, 
+                    new FaceAnalyzeResponse
+                    {
+                        OtherErrorMessage = "Request not processed due to the following error(s):",
+                        OtherErrorContent = errorContent
+                    }));
             }
 
             Track("Vision_Face");

--- a/src/Orneholm.CognitiveWorkbench.Web/Models/ComputerVision/ComputerVisionAnalyzeResponse.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Models/ComputerVision/ComputerVisionAnalyzeResponse.cs
@@ -19,5 +19,10 @@ namespace Orneholm.CognitiveWorkbench.Web.Models.ComputerVision
         public OcrResult OcrResult { get; set; } = new OcrResult();
         
         public List<DetectedFace> FaceResult { get; set; } = new List<DetectedFace>();
+
+        public string ApiRequestErrorMessage { get; set; }
+        public string ApiRequestErrorContent { get; set; }
+        public string OtherErrorMessage { get; set; }
+        public string OtherErrorContent { get; set; }
     }
 }

--- a/src/Orneholm.CognitiveWorkbench.Web/Models/ComputerVision/ComputerVisionViewModel.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Models/ComputerVision/ComputerVisionViewModel.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http.Connections;
-
 namespace Orneholm.CognitiveWorkbench.Web.Models.ComputerVision
 {
     public class ComputerVisionViewModel
@@ -9,20 +7,39 @@ namespace Orneholm.CognitiveWorkbench.Web.Models.ComputerVision
             return new ComputerVisionViewModel
             {
                 IsAnalyzed = false,
-
+                
                 ComputerVisionAnalyzeRequest = new ComputerVisionAnalyzeRequest(),
                 ComputerVisionAnalyzeResponse = null
             };
         }
 
-        public static ComputerVisionViewModel Analyzed(ComputerVisionAnalyzeRequest computerVisionAnalyzeRequest, ComputerVisionAnalyzeResponse computerVisionAnalyzeResponse)
+        public static ComputerVisionViewModel Analyzed(ComputerVisionAnalyzeRequest request, ComputerVisionAnalyzeResponse response)
         {
+            if (!string.IsNullOrWhiteSpace(response.ApiRequestErrorMessage)
+                || !string.IsNullOrWhiteSpace(response.ApiRequestErrorContent)
+                || !string.IsNullOrWhiteSpace(response.OtherErrorMessage)
+                || !string.IsNullOrWhiteSpace(response.OtherErrorContent))
+            {
+                return new ComputerVisionViewModel
+                {
+                    IsAnalyzed = false,
+                    
+                    ComputerVisionAnalyzeRequest = request,
+                    ComputerVisionAnalyzeResponse = null,
+                    
+                    ApiRequestErrorMessage = response.ApiRequestErrorMessage,
+                    ApiRequestErrorContent = response.ApiRequestErrorContent,
+                    OtherErrorMessage = response.OtherErrorMessage,
+                    OtherErrorContent = response.OtherErrorContent
+                };
+            }
+
             return new ComputerVisionViewModel
             {
                 IsAnalyzed = true,
 
-                ComputerVisionAnalyzeRequest = computerVisionAnalyzeRequest,
-                ComputerVisionAnalyzeResponse = computerVisionAnalyzeResponse
+                ComputerVisionAnalyzeRequest = request,
+                ComputerVisionAnalyzeResponse = response
             };
         }
 
@@ -30,5 +47,10 @@ namespace Orneholm.CognitiveWorkbench.Web.Models.ComputerVision
 
         public ComputerVisionAnalyzeRequest ComputerVisionAnalyzeRequest { get; internal set; } = new ComputerVisionAnalyzeRequest();
         public ComputerVisionAnalyzeResponse ComputerVisionAnalyzeResponse { get; internal set; }
+
+        public string ApiRequestErrorMessage { get; set; }
+        public string ApiRequestErrorContent { get; set; }
+        public string OtherErrorMessage { get; set; }
+        public string OtherErrorContent { get; set; }
     }
 }

--- a/src/Orneholm.CognitiveWorkbench.Web/Models/CustomVision/CustomVisionResponse.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Models/CustomVision/CustomVisionResponse.cs
@@ -9,5 +9,10 @@ namespace Orneholm.CognitiveWorkbench.Web.Models.CustomVision
         public ImageInfo ImageInfo { get; set; } = new ImageInfo();
 
         public List<PredictionModel> Predictions { get; set; } = new List<PredictionModel>();
+
+        public string ApiRequestErrorMessage { get; set; }
+        public string ApiRequestErrorContent { get; set; }
+        public string OtherErrorMessage { get; set; }
+        public string OtherErrorContent { get; set; }
     }
 }

--- a/src/Orneholm.CognitiveWorkbench.Web/Models/CustomVision/CustomVisionViewModel.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Models/CustomVision/CustomVisionViewModel.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http.Connections;
-
 namespace Orneholm.CognitiveWorkbench.Web.Models.CustomVision
 {
     public class CustomVisionViewModel
@@ -15,14 +13,33 @@ namespace Orneholm.CognitiveWorkbench.Web.Models.CustomVision
             };
         }
 
-        public static CustomVisionViewModel Analyzed(CustomVisionRequest customVisionAnalyzeRequest, CustomVisionResponse customVisionAnalyzeResponse)
+        public static CustomVisionViewModel Analyzed(CustomVisionRequest request, CustomVisionResponse response)
         {
+            if (!string.IsNullOrWhiteSpace(response.ApiRequestErrorMessage)
+                || !string.IsNullOrWhiteSpace(response.ApiRequestErrorContent)
+                || !string.IsNullOrWhiteSpace(response.OtherErrorMessage)
+                || !string.IsNullOrWhiteSpace(response.OtherErrorContent))
+            {
+                return new CustomVisionViewModel
+                {
+                    IsAnalyzed = false,
+                    
+                    CustomVisionAnalyzeRequest = request,
+                    CustomVisionAnalyzeResponse = null,
+                    
+                    ApiRequestErrorMessage = response.ApiRequestErrorMessage,
+                    ApiRequestErrorContent = response.ApiRequestErrorContent,
+                    OtherErrorMessage = response.OtherErrorMessage,
+                    OtherErrorContent = response.OtherErrorContent
+                };
+            }
+
             return new CustomVisionViewModel
             {
                 IsAnalyzed = true,
 
-                CustomVisionAnalyzeRequest = customVisionAnalyzeRequest,
-                CustomVisionAnalyzeResponse = customVisionAnalyzeResponse
+                CustomVisionAnalyzeRequest = request,
+                CustomVisionAnalyzeResponse = response
             };
         }
 
@@ -30,5 +47,10 @@ namespace Orneholm.CognitiveWorkbench.Web.Models.CustomVision
 
         public CustomVisionRequest CustomVisionAnalyzeRequest { get; internal set; } = new CustomVisionRequest();
         public CustomVisionResponse CustomVisionAnalyzeResponse { get; internal set; }
+
+        public string ApiRequestErrorMessage { get; set; }
+        public string ApiRequestErrorContent { get; set; }
+        public string OtherErrorMessage { get; set; }
+        public string OtherErrorContent { get; set; }
     }
 }

--- a/src/Orneholm.CognitiveWorkbench.Web/Models/Face/FaceAnalyzeResponse.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Models/Face/FaceAnalyzeResponse.cs
@@ -11,5 +11,10 @@ namespace Orneholm.CognitiveWorkbench.Web.Models.Face
         public List<FaceAttributeType> FaceAttributes { get; set; } = new List<FaceAttributeType>();
 
         public List<FaceAnalyzeItem> FaceResult { get; set; } = new List<FaceAnalyzeItem>();
+
+        public string ApiRequestErrorMessage { get; set; }
+        public string ApiRequestErrorContent { get; set; }
+        public string OtherErrorMessage { get; set; }
+        public string OtherErrorContent { get; set; }
     }
 }

--- a/src/Orneholm.CognitiveWorkbench.Web/Models/Face/FaceViewModel.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Models/Face/FaceViewModel.cs
@@ -13,14 +13,33 @@ namespace Orneholm.CognitiveWorkbench.Web.Models.Face
             };
         }
 
-        public static FaceViewModel Analyzed(FaceAnalyzeRequest faceAnalyzeRequest, FaceAnalyzeResponse faceAnalyzeResponse)
+        public static FaceViewModel Analyzed(FaceAnalyzeRequest request, FaceAnalyzeResponse response)
         {
+            if (!string.IsNullOrWhiteSpace(response.ApiRequestErrorMessage)
+                || !string.IsNullOrWhiteSpace(response.ApiRequestErrorContent)
+                || !string.IsNullOrWhiteSpace(response.OtherErrorMessage)
+                || !string.IsNullOrWhiteSpace(response.OtherErrorContent))
+            {
+                return new FaceViewModel
+                {
+                    IsAnalyzed = false,
+                    
+                    FaceAnalyzeRequest = request,
+                    FaceAnalyzeResponse = null,
+                    
+                    ApiRequestErrorMessage = response.ApiRequestErrorMessage,
+                    ApiRequestErrorContent = response.ApiRequestErrorContent,
+                    OtherErrorMessage = response.OtherErrorMessage,
+                    OtherErrorContent = response.OtherErrorContent
+                };
+            }
+
             return new FaceViewModel
             {
                 IsAnalyzed = true,
 
-                FaceAnalyzeRequest = faceAnalyzeRequest,
-                FaceAnalyzeResponse = faceAnalyzeResponse
+                FaceAnalyzeRequest = request,
+                FaceAnalyzeResponse = response
             };
         }
 
@@ -28,5 +47,10 @@ namespace Orneholm.CognitiveWorkbench.Web.Models.Face
 
         public FaceAnalyzeRequest FaceAnalyzeRequest { get; internal set; } = new FaceAnalyzeRequest();
         public FaceAnalyzeResponse FaceAnalyzeResponse { get; internal set; }
+
+        public string ApiRequestErrorMessage { get; set; }
+        public string ApiRequestErrorContent { get; set; }
+        public string OtherErrorMessage { get; set; }
+        public string OtherErrorContent { get; set; }
     }
 }

--- a/src/Orneholm.CognitiveWorkbench.Web/Services/ImageCustomVisionAnalyzer.cs
+++ b/src/Orneholm.CognitiveWorkbench.Web/Services/ImageCustomVisionAnalyzer.cs
@@ -4,6 +4,8 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Azure.CognitiveServices.Vision.CustomVision.Prediction;
 using Microsoft.Azure.CognitiveServices.Vision.CustomVision.Prediction.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Orneholm.CognitiveWorkbench.Web.Models.CustomVision;
 
 namespace Orneholm.CognitiveWorkbench.Web.Services
@@ -29,13 +31,40 @@ namespace Orneholm.CognitiveWorkbench.Web.Services
             var imageInfo = ImageInfoProcessor.GetImageInfo(url, _httpClientFactory);
 
             // Combine
-            await Task.WhenAll(imageAnalysis, imageInfo);
+            var task = Task.WhenAll(imageAnalysis, imageInfo);
 
-            return new CustomVisionResponse
+            try
             {
-                ImageInfo = imageInfo.Result,
-                Predictions = imageAnalysis.Result.Predictions.ToList()
-            };
+                await task;
+
+                return new CustomVisionResponse
+                {
+                    ImageInfo = imageInfo.Result,
+                    Predictions = imageAnalysis.Result.Predictions.ToList()
+                };
+            }
+            catch (CustomVisionErrorException ex)
+            {
+                var exceptionMessage = ex.Response.Content;
+                var parsedJson = JToken.Parse(exceptionMessage);
+
+                if (ex.Response.StatusCode == System.Net.HttpStatusCode.BadRequest)
+                {
+                    return new CustomVisionResponse
+                    {
+                        ApiRequestErrorMessage = $"Bad request thrown by the underlying API from Microsoft:",
+                        ApiRequestErrorContent = parsedJson.ToString(Formatting.Indented)
+                    };
+                }
+                else
+                {
+                    return new CustomVisionResponse
+                    {
+                        OtherErrorMessage = $"Error thrown by the underlying API from Microsoft:",
+                        OtherErrorContent = parsedJson.ToString(Formatting.Indented)
+                    };
+                }
+            }
         }
 
         private async Task<ImagePrediction> CustomVisionAnalyzeImage(string url, Guid projectId, string publishedName, CustomVisionProjectType projectType)

--- a/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/ComputerVision.cshtml
+++ b/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/ComputerVision.cshtml
@@ -47,7 +47,7 @@
 
                             <div class="form-group">
                                 <label asp-for="ComputerVisionAnalyzeRequest.ImageUrl">Image URL</label>
-                                <input type="url" required class="cwb-input-remember form-control" placeholder="https://example.org/url-to/image.jpg" asp-for="ComputerVisionAnalyzeRequest.ImageUrl" name="ImageUrl" />
+                                <input type="url" class="cwb-input-remember form-control" placeholder="https://example.org/url-to/image.jpg" asp-for="ComputerVisionAnalyzeRequest.ImageUrl" name="ImageUrl" />
                             </div>
 
                             <h3>Analyze</h3>
@@ -55,7 +55,7 @@
                                 <div class="col">
                                     <div class="form-group">
                                         <label asp-for="ComputerVisionAnalyzeRequest.ImageAnalysisLanguage">Image Analysis Language</label>
-                                        <select asp-for="ComputerVisionAnalyzeRequest.ImageAnalysisLanguage" asp-items="Html.GetEnumSelectList<AnalysisLanguage>()" required class="cwb-input-remember form-control" name="ImageAnalysisLanguage">
+                                        <select asp-for="ComputerVisionAnalyzeRequest.ImageAnalysisLanguage" asp-items="Html.GetEnumSelectList<AnalysisLanguage>()" class="cwb-input-remember form-control" name="ImageAnalysisLanguage">
                                         </select>
                                     </div>
                                 </div>
@@ -66,7 +66,7 @@
                                 <div class="col">
                                     <div class="form-group">
                                         <label asp-for="ComputerVisionAnalyzeRequest.ImageReadV3Language">Image Read Language (Read operation)</label>
-                                        <select asp-for="ComputerVisionAnalyzeRequest.ImageReadV3Language" asp-items="Html.GetEnumSelectList<ReadV3Language>()" required class="cwb-input-remember form-control" name="ImageReadV3Language">
+                                        <select asp-for="ComputerVisionAnalyzeRequest.ImageReadV3Language" asp-items="Html.GetEnumSelectList<ReadV3Language>()" class="cwb-input-remember form-control" name="ImageReadV3Language">
                                         </select>
                                     </div>
                                 </div>
@@ -74,7 +74,7 @@
                                 <div class="col">
                                     <div class="form-group">
                                         <label asp-for="ComputerVisionAnalyzeRequest.ImageOcrLanguage">Image OCR Language (OCR operation)</label>
-                                        <select asp-for="ComputerVisionAnalyzeRequest.ImageOcrLanguage" asp-items="Html.GetEnumSelectList<OcrLanguages>()" required class="cwb-input-remember form-control" name="ImageOcrLanguage">
+                                        <select asp-for="ComputerVisionAnalyzeRequest.ImageOcrLanguage" asp-items="Html.GetEnumSelectList<OcrLanguages>()" class="cwb-input-remember form-control" name="ImageOcrLanguage">
                                         </select>
                                     </div>
                                 </div>
@@ -94,12 +94,12 @@
                                 </div>
                             }
 
-                            @if(!string.IsNullOrWhiteSpace(Model.OtherErrorMessage) || !string.IsNullOrWhiteSpace(Model.OtherErrorMessage))
+                            @if(!string.IsNullOrWhiteSpace(Model.OtherErrorMessage) || !string.IsNullOrWhiteSpace(Model.OtherErrorContent))
                             {
                                 <div class="alert alert-danger alert-dismissible fade show" role="alert">
                                     <h4 class="alert-heading">Error</h4>
                                     @Model.OtherErrorMessage
-                                    <pre>@Model.OtherErrorMessage</pre>
+                                    <pre>@Model.OtherErrorContent</pre>
                                     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                                         <span aria-hidden="true">&times;</span>
                                     </button>
@@ -121,11 +121,11 @@
                             <div class="form-row">
                                 <div class="form-group col-md-6">
                                     <label asp-for="ComputerVisionAnalyzeRequest.ComputerVisionSubscriptionKey">Computer Vision - Subscription Key</label>
-                                    <input type="password" required class="cwb-input-remember form-control" placeholder="zq8lp6z7cqtew6h4c0bxy0r5cqx3in36" asp-for="ComputerVisionAnalyzeRequest.ComputerVisionSubscriptionKey" name="ComputerVisionSubscriptionKey" />
+                                    <input type="password" class="cwb-input-remember form-control" placeholder="zq8lp6z7cqtew6h4c0bxy0r5cqx3in36" asp-for="ComputerVisionAnalyzeRequest.ComputerVisionSubscriptionKey" name="ComputerVisionSubscriptionKey" />
                                 </div>
                                 <div class="form-group col-md-6">
                                     <label asp-for="ComputerVisionAnalyzeRequest.ComputerVisionEndpoint">Computer Vision - Endpoint</label>
-                                    <input type="url" required class="cwb-input-remember form-control" placeholder="https://[COMPUTERVISION-RESOURCENAME].cognitiveservices.azure.com/" asp-for="ComputerVisionAnalyzeRequest.ComputerVisionEndpoint" name="ComputerVisionEndpoint" />
+                                    <input type="url" class="cwb-input-remember form-control" placeholder="https://[COMPUTERVISION-RESOURCENAME].cognitiveservices.azure.com/" asp-for="ComputerVisionAnalyzeRequest.ComputerVisionEndpoint" name="ComputerVisionEndpoint" />
                                 </div>
                             </div>
                         </div>

--- a/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/ComputerVision.cshtml
+++ b/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/ComputerVision.cshtml
@@ -81,6 +81,30 @@
                             </div>
 
                             <button type="submit" class="btn btn-primary">Analyze</button>
+
+                            @if(!string.IsNullOrWhiteSpace(Model.ApiRequestErrorMessage) || !string.IsNullOrWhiteSpace(Model.ApiRequestErrorContent))
+                            {
+                                <div class="alert alert-warning alert-dismissible fade show" role="alert">
+                                    <h4 class="alert-heading">Warning</h4>
+                                    @Model.ApiRequestErrorMessage
+                                    <pre>@Model.ApiRequestErrorContent</pre>
+                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                        <span aria-hidden="true">&times;</span>
+                                    </button>
+                                </div>
+                            }
+
+                            @if(!string.IsNullOrWhiteSpace(Model.OtherErrorMessage) || !string.IsNullOrWhiteSpace(Model.OtherErrorMessage))
+                            {
+                                <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                                    <h4 class="alert-heading">Error</h4>
+                                    @Model.OtherErrorMessage
+                                    <pre>@Model.OtherErrorMessage</pre>
+                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                        <span aria-hidden="true">&times;</span>
+                                    </button>
+                                </div>
+                            }
                         </div>
                         <div class="tab-pane fade" id="cwb-form-computervision-settings">
                             <p>
@@ -381,7 +405,6 @@
                 </div>
             </section>
         }
-
 
         @section Scripts
         {

--- a/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/CustomVision.cshtml
+++ b/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/CustomVision.cshtml
@@ -76,6 +76,30 @@
                             </div>
 
                             <button type="submit" class="btn btn-primary">Analyze</button>
+                            
+                            @if(!string.IsNullOrWhiteSpace(Model.ApiRequestErrorMessage) || !string.IsNullOrWhiteSpace(Model.ApiRequestErrorContent))
+                            {
+                                <div class="alert alert-warning alert-dismissible fade show" role="alert">
+                                    <h4 class="alert-heading">Warning</h4>
+                                    @Model.ApiRequestErrorMessage
+                                    <pre>@Model.ApiRequestErrorContent</pre>
+                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                        <span aria-hidden="true">&times;</span>
+                                    </button>
+                                </div>
+                            }
+
+                            @if(!string.IsNullOrWhiteSpace(Model.OtherErrorMessage) || !string.IsNullOrWhiteSpace(Model.OtherErrorMessage))
+                            {
+                                <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                                    <h4 class="alert-heading">Error</h4>
+                                    @Model.OtherErrorMessage
+                                    <pre>@Model.OtherErrorMessage</pre>
+                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                        <span aria-hidden="true">&times;</span>
+                                    </button>
+                                </div>
+                            }
                         </div>
                         <div class="tab-pane fade" id="cwb-form-customvision-settings">
                             <p>

--- a/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/CustomVision.cshtml
+++ b/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/CustomVision.cshtml
@@ -89,12 +89,12 @@
                                 </div>
                             }
 
-                            @if(!string.IsNullOrWhiteSpace(Model.OtherErrorMessage) || !string.IsNullOrWhiteSpace(Model.OtherErrorMessage))
+                            @if(!string.IsNullOrWhiteSpace(Model.OtherErrorMessage) || !string.IsNullOrWhiteSpace(Model.OtherErrorContent))
                             {
                                 <div class="alert alert-danger alert-dismissible fade show" role="alert">
                                     <h4 class="alert-heading">Error</h4>
                                     @Model.OtherErrorMessage
-                                    <pre>@Model.OtherErrorMessage</pre>
+                                    <pre>@Model.OtherErrorContent</pre>
                                     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                                         <span aria-hidden="true">&times;</span>
                                     </button>

--- a/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/Face.cshtml
+++ b/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/Face.cshtml
@@ -94,6 +94,30 @@
                             </div>
 
                             <button type="submit" class="btn btn-primary">Analyze</button>
+
+                            @if(!string.IsNullOrWhiteSpace(Model.ApiRequestErrorMessage) || !string.IsNullOrWhiteSpace(Model.ApiRequestErrorContent))
+                            {
+                                <div class="alert alert-warning alert-dismissible fade show" role="alert">
+                                    <h4 class="alert-heading">Warning</h4>
+                                    @Model.ApiRequestErrorMessage
+                                    <pre>@Model.ApiRequestErrorContent</pre>
+                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                        <span aria-hidden="true">&times;</span>
+                                    </button>
+                                </div>
+                            }
+
+                            @if(!string.IsNullOrWhiteSpace(Model.OtherErrorMessage) || !string.IsNullOrWhiteSpace(Model.OtherErrorMessage))
+                            {
+                                <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                                    <h4 class="alert-heading">Error</h4>
+                                    @Model.OtherErrorMessage
+                                    <pre>@Model.OtherErrorMessage</pre>
+                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                        <span aria-hidden="true">&times;</span>
+                                    </button>
+                                </div>
+                            }
                         </div>
                         <div class="tab-pane fade" id="cwb-form-face-settings">
                             <p>

--- a/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/Face.cshtml
+++ b/src/Orneholm.CognitiveWorkbench.Web/Views/Vision/Face.cshtml
@@ -107,12 +107,12 @@
                                 </div>
                             }
 
-                            @if(!string.IsNullOrWhiteSpace(Model.OtherErrorMessage) || !string.IsNullOrWhiteSpace(Model.OtherErrorMessage))
+                            @if(!string.IsNullOrWhiteSpace(Model.OtherErrorMessage) || !string.IsNullOrWhiteSpace(Model.OtherErrorContent))
                             {
                                 <div class="alert alert-danger alert-dismissible fade show" role="alert">
                                     <h4 class="alert-heading">Error</h4>
                                     @Model.OtherErrorMessage
-                                    <pre>@Model.OtherErrorMessage</pre>
+                                    <pre>@Model.OtherErrorContent</pre>
                                     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                                         <span aria-hidden="true">&times;</span>
                                     </button>


### PR DESCRIPTION
This pull request allows:

- to display details about invalid request parameters (ex: subscription key not provided) - example:
![image](https://user-images.githubusercontent.com/6305666/104943669-65b1c080-59b6-11eb-86bf-81230f428fa3.png)

- to display "Bad request" returns from the API to the user instead of creating a 500 error on the website - example:
![image](https://user-images.githubusercontent.com/6305666/104943717-73ffdc80-59b6-11eb-8af6-10cfde1da9d7.png)

In this last case, the response content is displayed to the user because it brings additional details about the error, for example if the image is too big or the url is not accessible.

It should resolve #8 